### PR TITLE
Fix product page promotion price display

### DIFF
--- a/promotionscountdown/promotionscountdown.php
+++ b/promotionscountdown/promotionscountdown.php
@@ -147,7 +147,8 @@ class PromotionsCountdown extends Module
     public function hookDisplayProductPriceBlock($params)
     {
         try {
-            if ($params['type'] !== 'after') {
+            // Gestisce sia il prezzo principale (before/price) che il blocco aggiuntivo (after)
+            if (!in_array($params['type'], ['before', 'price', 'after'])) {
                 return;
             }
 
@@ -269,6 +270,12 @@ class PromotionsCountdown extends Module
                     'discounted_price_formatted' => Tools::displayPrice($discounted_price_tax_incl),
                 ]);
                 
+                // Per il prezzo principale (before/price), sovrascriviamo il prezzo
+                if (in_array($params['type'], ['before', 'price'])) {
+                    return $this->display(__FILE__, 'product_single_override.tpl');
+                }
+                
+                // Per il blocco aggiuntivo (after), mostriamo il template di debug
                 return $this->display(__FILE__, 'product_price_discount.tpl');
             }
         } catch (Exception $e) {

--- a/promotionscountdown/views/templates/hook/product_single_override.tpl
+++ b/promotionscountdown/views/templates/hook/product_single_override.tpl
@@ -6,6 +6,49 @@
             display: none !important;
         }
         
+        /* Nascondi il prezzo originale e mostra il nostro */
+        .product-prices .current-price,
+        .product-prices .regular-price,
+        .product-prices .price,
+        .current-price,
+        .regular-price,
+        .price,
+        .product-price,
+        .product-price-container,
+        .price-box,
+        .price-container {
+            display: none !important;
+        }
+        
+        /* Stile per il nostro prezzo personalizzato */
+        .promotion-price-override {
+            font-size: 24px;
+            font-weight: bold;
+            color: #333;
+            margin: 10px 0;
+        }
+        
+        .promotion-price-override .original-price {
+            text-decoration: line-through;
+            color: #999;
+            font-size: 18px;
+            margin-right: 10px;
+        }
+        
+        .promotion-price-override .discounted-price {
+            color: #e74c3c;
+            font-size: 28px;
+        }
+        
+        .promotion-price-override .discount-badge {
+            background: #e74c3c;
+            color: white;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 14px;
+            margin-left: 10px;
+        }
+        
         /* Stile per la nostra bandiera di promozione nella pagina del prodotto */
         .promotion-countdown-flag-single {
             background: linear-gradient(135deg, #ff6b6b, #ff8e8e);
@@ -76,12 +119,25 @@
         }
     </style>
     
+    <!-- Sovrascrivi il prezzo del prodotto -->
+    <div class="promotion-price-override">
+        <span class="original-price">{if isset($original_price_formatted)}{$original_price_formatted}{else}{$original_price|string_format:"%.2f"} €{/if}</span>
+        <span class="discounted-price">{if isset($discounted_price_formatted)}{$discounted_price_formatted}{else}{$discounted_price|string_format:"%.2f"} €{/if}</span>
+        <span class="discount-badge">-{$product_discount.discount_percent}%</span>
+    </div>
+    
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // Nascondi tutte le bandiere di sconto native nella pagina del prodotto
             var nativeFlags = document.querySelectorAll('.product-flags .product-flag.discount, .product-flags .product-flag.discount-percentage');
             nativeFlags.forEach(function(flag) {
                 flag.style.display = 'none';
+            });
+            
+            // Nascondi i prezzi originali di PrestaShop
+            var originalPrices = document.querySelectorAll('.product-prices .current-price, .product-prices .regular-price, .product-prices .price, .current-price, .regular-price, .price, .product-price, .product-price-container, .price-box, .price-container');
+            originalPrices.forEach(function(price) {
+                price.style.display = 'none';
             });
             
             // Cerca un container appropriato per inserire la nostra bandiera


### PR DESCRIPTION
Display winning promotion price on product pages by overriding PrestaShop's default price display.

The `displayProductPriceBlock` hook was previously only handling the `after` type. This meant the main product price (typically rendered by `before` or `price` types) was not being overridden. This PR extends the hook to manage these types, allowing the module to inject its own price display, ensuring the promotional price is visible on the product page.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ab49e26-cf65-4f94-845b-67b08a8857ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ab49e26-cf65-4f94-845b-67b08a8857ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

